### PR TITLE
feat: Enable Spring Boot DevTools auto-reload for dev profile

### DIFF
--- a/endpoint-collector-backend/pom.xml
+++ b/endpoint-collector-backend/pom.xml
@@ -80,6 +80,12 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <!-- Spring boot security dependencies-->

--- a/endpoint-collector-backend/src/main/resources/application-dev.properties
+++ b/endpoint-collector-backend/src/main/resources/application-dev.properties
@@ -1,6 +1,12 @@
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update
 
+# DevTools Configuration for Auto-Reload
+spring.devtools.restart.enabled=true
+spring.devtools.restart.additional-paths=src/main/java
+spring.devtools.restart.exclude=static/**,public/**
+spring.devtools.livereload.enabled=true
+
 # Setting Spring context path & port
 server.servlet.context-path=/${ext.endpoint.collector.service.name}
 server.port=6082


### PR DESCRIPTION
- Add spring-boot-devtools dependency to pom.xml
- Configure DevTools auto-reload in application-dev.properties
- Enable LiveReload for instant browser refresh
- Improve development experience with automatic restart

Related to hvantran/project-management#183